### PR TITLE
Fix npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "bytes",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "description": "byte size string parser / serializer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visionmedia/bytes.js.git"
+  },
   "version": "0.2.1",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
fixes warnings such as 

```
npm WARN package.json bytes@0.2.1 No repository field.
```
