### PR TITLE
Output KB, MB, GB, support case-insensitive input

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@
 
 module.exports = function(size) {
   if ('number' == typeof size) return convert(size);
-  var parts = size.match(/^(\d+(?:\.\d+)?) *(kb|mb|gb)$/)
+  var parts = size.match(/^(\d+(?:\.\d+)?) *(kb|mb|gb)$/i)
     , n = parseFloat(parts[1])
-    , type = parts[2];
+    , type = parts[2].toLowerCase();
 
   var map = {
       kb: 1 << 10
@@ -32,8 +32,8 @@ module.exports = function(size) {
 
 function convert (b) {
   var gb = 1 << 30, mb = 1 << 20, kb = 1 << 10;
-  if (b >= gb) return (Math.round(b / gb * 100) / 100) + 'gb';
-  if (b >= mb) return (Math.round(b / mb * 100) / 100) + 'mb';
-  if (b >= kb) return (Math.round(b / kb * 100) / 100) + 'kb';
-  return b + 'b';
+  if (b >= gb) return (Math.round(b / gb * 100) / 100) + 'GB';
+  if (b >= mb) return (Math.round(b / mb * 100) / 100) + 'MB';
+  if (b >= kb) return (Math.round(b / kb * 100) / 100) + 'KB';
+  return b + 'B';
 }

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -21,4 +21,9 @@ describe('bytes(str)', function(){
   it('should allow whitespace', function(){
     bytes('1 mb').should.equal(1024 * 1024);
   })
+  it('should be case-insensitive', function(){
+    bytes('1KB').should.equal(1 << 10);
+    bytes('1Mb').should.equal(1 << 20);
+    bytes('1GB').should.equal(1 << 30);
+  })
 })

--- a/test/tostring.js
+++ b/test/tostring.js
@@ -1,31 +1,32 @@
 
 var bytes = require('..')
+  , tb = 1 << 40
   , gb = 1 << 30
   , mb = 1 << 20
   , kb = 1 << 10;
 
 describe('bytes(number)', function () {
   it('should convert numbers < 1024 to `bytes` string', function () {
-    bytes(200).should.eql('200b');
+    bytes(200).should.eql('200B');
   })
 
-  it('should convert numbers >= 1024 to kb string', function () {
-    bytes(kb).should.equal('1kb')
-    bytes(2 * kb).should.equal('2kb')
+  it('should convert numbers >= 1024 to KB string', function () {
+    bytes(kb).should.equal('1KB')
+    bytes(2 * kb).should.equal('2KB')
   })
 
-  it('should convert numbers >= 1048576 to mb string', function () {
-    bytes(mb).should.equal('1mb')
-    bytes(2 * mb).should.equal('2mb')
+  it('should convert numbers >= 1048576 to MB string', function () {
+    bytes(mb).should.equal('1MB')
+    bytes(2 * mb).should.equal('2MB')
   })
 
-  it('should convert numbers >= (1 << 30) to gb string', function () {
-    bytes(gb).should.equal('1gb')
-    bytes(2 * gb).should.equal('2gb')
+  it('should convert numbers >= (1 << 30) to GB string', function () {
+    bytes(gb).should.equal('1GB')
+    bytes(2 * gb).should.equal('2GB')
   })
 
   it('should support floats', function () {
-    bytes(1.2 * mb).should.equal('1.2mb')
-    bytes(1.2 * kb).should.equal('1.2kb')
+    bytes(1.2 * mb).should.equal('1.2MB')
+    bytes(1.2 * kb).should.equal('1.2KB')
   })
 })


### PR DESCRIPTION
Hi,
the output is there to (try to) stick to usual capitalization,
and the input supports both.
This is a less opinionated version of https://github.com/visionmedia/bytes.js/pull/7.