### PR TITLE
Uppercase support, tests and graceful fail. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,10 @@
 
 module.exports = function(size) {
   if ('number' == typeof size) return convert(size);
-  var parts = size.match(/^(\d+(?:\.\d+)?) *(kb|mb|gb|tb)$/)
-    , n = parseFloat(parts[1])
-    , type = parts[2];
+  var n, type, parts = size.match(/^(\d+(?:\.\d+)?) *(kb|mb|gb|tb)$/i);
+  if(parts === null) return;
+  n = parseFloat(parts[1]);
+  type = parts[2].toLowerCase();
 
   var map = {
       kb: 1 << 10

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -1,4 +1,5 @@
 
+var should = require('should');
 var bytes = require('..');
 
 describe('bytes(str)', function(){

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -11,12 +11,24 @@ describe('bytes(str)', function(){
     bytes('1mb').should.equal(1024 * 1024);
   })
 
+  it('should parse MB', function(){
+    bytes('1MB').should.equal(1024 * 1024);
+  })
+
   it('should parse gb', function(){
     bytes('5gb').should.equal(5 * 1024 * 1024 * 1024);
   })
 
+  it('should parse Gb', function(){
+    bytes('5Gb').should.equal(5 * 1024 * 1024 * 1024);
+  })
+
   it('should parse tb', function(){
     bytes('6tb').should.equal(6 * 1024 * 1024 * 1024 * 1024);
+  })
+
+  it('should parse tB', function(){
+    bytes('6tB').should.equal(6 * 1024 * 1024 * 1024 * 1024);
   })
 
   it('should support floats', function(){
@@ -25,5 +37,9 @@ describe('bytes(str)', function(){
 
   it('should allow whitespace', function(){
     bytes('1 mb').should.equal(1024 * 1024);
+  })
+
+  it('should fail gracefully', function(){
+    should.not.exist(bytes('1xx'));
   })
 })

--- a/test/tostring.js
+++ b/test/tostring.js
@@ -1,4 +1,5 @@
 
+var should = require('should');
 var bytes = require('..')
   , tb = (1 << 30) * 1024
   , gb = 1 << 30


### PR DESCRIPTION
The name of the package is bytes - so obviously we're not concerned with confusing bits and their associated abbrs.  Why not support 5mb and 5MB without throwing an error.  

I found that mocha@1.19.0 requires us to require should in our tests.  
And I added a few tests for UC chars and graceful failure.

 