### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/visionmedia/bytes.js.git"
   },
   "version": "1.0.0",
+  "license": "MIT",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Allows license to be read programatically.
