### PR TITLE
Fixing browserify issue, see keystonejs/keystone#1332

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var convertFunction = require(__dirname + '/lib/byte-convert.js');
-var parseFunction = require(__dirname + '/lib/byte-parse.js');
+var convertFunction = require('./lib/byte-convert.js');
+var parseFunction = require('./lib/byte-parse.js');
 
 /**
  * Convert the given value in bytes into a string or parse to string to an integer in bytes.


### PR DESCRIPTION
Hey @tj,

I'm not sure what the reason is behind using `__dirname` in the `require` statements here, but it's causing browserify build issues that are fixed by changing it to a more standard `'./lib/...'` path.

If you could merge this and pubilsh that would be great, this is currently breaking the latest version of KeystoneJS (see keystonejs/keystone#1332)

Thanks