### PR TITLE
Remove node.extends dependency

### DIFF
--- a/lib/byte-convert.js
+++ b/lib/byte-convert.js
@@ -1,17 +1,5 @@
 'use strict';
 
-var extend = require('node.extend');
-
-/**
- * Default options.
- *
- * @type {{case: string|null, thousandsSeparator: string|null}}
- */
-
-var defaultOptions = {
-  thousandsSeparator: ''
-};
-
 /**
  * Convert the value given in bytes into bytes, KB, MB, GB or TB.
  *
@@ -64,14 +52,13 @@ module.exports = function (value, options) {
     return null;
   }
 
-  options = extend({}, defaultOptions, options);
-
   var converterResult = convertValue(value);
   var convertedValue = converterResult.value;
+  var thousandsSeparator = (options && options.thousandsSeparator) || '';
   var unit = converterResult.unit;
 
-  if (options.thousandsSeparator) {
-    convertedValue = convertedValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandsSeparator);
+  if (thousandsSeparator) {
+    convertedValue = convertedValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparator);
   }
 
   return convertedValue + unit;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   },
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha --check-leaks"
+    "test": "mocha --check-leaks"
   },
   "dependencies": {
     "node.extend": "*"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "scripts": {
     "test": "mocha --check-leaks"
   },
-  "dependencies": {
-    "node.extend": "*"
-  },
   "devDependencies": {
     "chai": "*",
     "mocha": "*"


### PR DESCRIPTION
The `node.extends` dependency that came with 2.0.0 is unnecessary and is just super breaking, being on the version `*` and then having commits like https://github.com/dreamerslab/node.extend/commit/f600c86622e73e83795936d9bc134f4eaebca2cf

Please @tj release a version without this dependency :) 