### PR TITLE
Allow custom precision

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 |-------------------|--------|-----------------------------------------------------------------------------------------|
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
 | precision | `number`&#124;`null` | Maximum number of decimal places to include in output. Default: `2` |
+| fixed | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default: `false` |
 
 **Returns**
 
@@ -51,6 +52,9 @@ bytes(1000, {thousandsSeparator: ' '});
 
 bytes(1024 * 1.7, {precision: 0});
 // output: '2kB'
+
+bytes(1024, {precision: 3, fixed: true});
+// output: '1.000kB'
 ```
 
 #### bytes.parse(string value): number|null

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | Property          | Type   | Description                                                                             |
 |-------------------|--------|-----------------------------------------------------------------------------------------|
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
-| precision | `number`&#124;`null` | Maximum number of decimal places to include in output. Default: `2` |
+| decimalPlaces | `number`&#124;`null` | Maximum number of decimal places to include in output. Default: `2` |
 | fixed | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default: `false` |
 
 **Returns**
@@ -50,10 +50,10 @@ bytes(1000);
 bytes(1000, {thousandsSeparator: ' '});
 // output: '1 000B'
 
-bytes(1024 * 1.7, {precision: 0});
+bytes(1024 * 1.7, {decimalPlaces: 0});
 // output: '2kB'
 
-bytes(1024, {precision: 3, fixed: true});
+bytes(1024, {decimalPlaces: 3, fixed: true});
 // output: '1.000kB'
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | Property          | Type   | Description                                                                             |
 |-------------------|--------|-----------------------------------------------------------------------------------------|
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
+| precision | `number`&#124;`null` | Maximum number of decimal places to include in output. Default: `2` |
 
 **Returns**
 
@@ -47,6 +48,9 @@ bytes(1000);
 
 bytes(1000, {thousandsSeparator: ' '});
 // output: '1 000B'
+
+bytes(1024 * 1.7, {precision: 0});
+// output: '2kB'
 ```
 
 #### bytes.parse(string value): number|null

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var map = {
  * @param {{
  *  case: [string],
  *  thousandsSeparator: [string]
- *  precision: [number]
+ *  decimalPlaces: [number]
  *  }} [options] bytes options.
  *
  * @returns {string|number|null}
@@ -63,7 +63,7 @@ function bytes(value, options) {
  * @param {number} value
  * @param {object} [options]
  * @param {string} [options.thousandsSeparator=]
- * @param {number} [options.precision=2]
+ * @param {number} [options.decimalPlaces=2]
  * @public
  */
 
@@ -74,7 +74,7 @@ function format(val, options) {
 
   var mag = Math.abs(val);
   var thousandsSeparator = (options && options.thousandsSeparator) || '';
-  var precision = (options && (typeof options.precision === 'number')) ? options.precision : 2;
+  var decimalPlaces = (options && (typeof options.decimalPlaces === 'number')) ? options.decimalPlaces : 2;
   var fixed = Boolean(options && options.fixed);
   var unit = 'B';
   var value = val;
@@ -94,9 +94,9 @@ function format(val, options) {
   }
 
   if (fixed) {
-    value = value.toFixed(precision);
+    value = value.toFixed(decimalPlaces);
   } else {
-    var roundingValue = Math.pow(10, precision);
+    var roundingValue = Math.pow(10, decimalPlaces);
     value = Math.round(value * roundingValue) / roundingValue;
   }
 

--- a/index.js
+++ b/index.js
@@ -75,22 +75,29 @@ function format(val, options) {
   var mag = Math.abs(val);
   var thousandsSeparator = (options && options.thousandsSeparator) || '';
   var precision = (options && (typeof options.precision === 'number')) ? options.precision : 2;
+  var fixed = Boolean(options && options.fixed);
   var unit = 'B';
   var value = val;
-  var roundingValue = Math.pow(10, precision);
 
   if (mag >= map.tb) {
-    value = Math.round(value / map.tb * roundingValue) / roundingValue;
+    value /= map.tb;
     unit = 'TB';
   } else if (mag >= map.gb) {
-    value = Math.round(value / map.gb * roundingValue) / roundingValue;
+    value /= map.gb;
     unit = 'GB';
   } else if (mag >= map.mb) {
-    value = Math.round(value / map.mb * roundingValue) / roundingValue;
+    value /= map.mb;
     unit = 'MB';
   } else if (mag >= map.kb) {
-    value = Math.round(value / map.kb * roundingValue) / roundingValue;
+    value /= map.kb;
     unit = 'kB';
+  }
+
+  if (fixed) {
+    value = value.toFixed(precision);
+  } else {
+    var roundingValue = Math.pow(10, precision);
+    value = Math.round(value * roundingValue) / roundingValue;
   }
 
   if (thousandsSeparator) {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var map = {
  * @param {{
  *  case: [string],
  *  thousandsSeparator: [string]
+ *  precision: [number]
  *  }} [options] bytes options.
  *
  * @returns {string|number|null}
@@ -62,6 +63,7 @@ function bytes(value, options) {
  * @param {number} value
  * @param {object} [options]
  * @param {string} [options.thousandsSeparator=]
+ * @param {number} [options.precision=2]
  * @public
  */
 
@@ -72,20 +74,22 @@ function format(val, options) {
 
   var mag = Math.abs(val);
   var thousandsSeparator = (options && options.thousandsSeparator) || '';
+  var precision = (options && (typeof options.precision === 'number')) ? options.precision : 2;
   var unit = 'B';
   var value = val;
+  var roundingValue = Math.pow(10, precision);
 
   if (mag >= map.tb) {
-    value = Math.round(value / map.tb * 100) / 100;
+    value = Math.round(value / map.tb * roundingValue) / roundingValue;
     unit = 'TB';
   } else if (mag >= map.gb) {
-    value = Math.round(value / map.gb * 100) / 100;
+    value = Math.round(value / map.gb * roundingValue) / roundingValue;
     unit = 'GB';
   } else if (mag >= map.mb) {
-    value = Math.round(value / map.mb * 100) / 100;
+    value = Math.round(value / map.mb * roundingValue) / roundingValue;
     unit = 'MB';
   } else if (mag >= map.kb) {
-    value = Math.round(value / map.kb * 100) / 100;
+    value = Math.round(value / map.kb * roundingValue) / roundingValue;
     unit = 'kB';
   }
 

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -67,19 +67,19 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(1000, {thousandsSeparator: ' '}).toLowerCase(), '1 000b');
   });
 
-  it('Should support custom precision', function(){
-    assert.equal(bytes.format(kb - 1, {precision: 0}).toLowerCase(), '1023b');
-    assert.equal(bytes.format(kb, {precision: 0}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.4 * kb, {precision: 0}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.5 * kb, {precision: 0}).toLowerCase(), '2kb');
-    assert.equal(bytes.format(kb - 1, {precision: 1}).toLowerCase(), '1023b');
-    assert.equal(bytes.format(kb, {precision: 1}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.04 * kb, {precision: 1}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.05 * kb, {precision: 1}).toLowerCase(), '1.1kb');
+  it('Should support custom number of decimal places', function(){
+    assert.equal(bytes.format(kb - 1, {decimalPlaces: 0}).toLowerCase(), '1023b');
+    assert.equal(bytes.format(kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.4 * kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.5 * kb, {decimalPlaces: 0}).toLowerCase(), '2kb');
+    assert.equal(bytes.format(kb - 1, {decimalPlaces: 1}).toLowerCase(), '1023b');
+    assert.equal(bytes.format(kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.04 * kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.05 * kb, {decimalPlaces: 1}).toLowerCase(), '1.1kb');
   });
 
-  it('Should support fixed precision', function(){
-    assert.equal(bytes.format(kb, {precision: 3, fixed: true}).toLowerCase(), '1.000kb');
+  it('Should support fixed number of decimal places', function(){
+    assert.equal(bytes.format(kb, {decimalPlaces: 3, fixed: true}).toLowerCase(), '1.000kb');
   });
 
   it('Should support floats', function(){

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -67,6 +67,17 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(1000, {thousandsSeparator: ' '}).toLowerCase(), '1 000b');
   });
 
+  it('Should support custom precision', function(){
+    assert.equal(bytes.format(kb - 1, {precision: 0}).toLowerCase(), '1023b');
+    assert.equal(bytes.format(kb, {precision: 0}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.4 * kb, {precision: 0}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.5 * kb, {precision: 0}).toLowerCase(), '2kb');
+    assert.equal(bytes.format(kb - 1, {precision: 1}).toLowerCase(), '1023b');
+    assert.equal(bytes.format(kb, {precision: 1}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.04 * kb, {precision: 1}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(1.05 * kb, {precision: 1}).toLowerCase(), '1.1kb');
+  });
+
   it('Should support floats', function(){
     assert.equal(bytes.format(1.2 * mb).toLowerCase(), '1.2mb');
     assert.equal(bytes.format(-1.2 * mb).toLowerCase(), '-1.2mb');

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -78,6 +78,10 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(1.05 * kb, {precision: 1}).toLowerCase(), '1.1kb');
   });
 
+  it('Should support fixed precision', function(){
+    assert.equal(bytes.format(kb, {precision: 3, fixed: true}).toLowerCase(), '1.000kb');
+  });
+
   it('Should support floats', function(){
     assert.equal(bytes.format(1.2 * mb).toLowerCase(), '1.2mb');
     assert.equal(bytes.format(-1.2 * mb).toLowerCase(), '-1.2mb');


### PR DESCRIPTION
This PR allows you to specify the maximum number of decimal places to include in the output of `bytes.format()`.

Examples:

```javascript
bytes(1024 * 1.12345, {precision: 3});
// output: '1.123kB'

bytes(1024 * 1.12345, {precision: 0});
// output: '1kB'
```

...note that this is a **maximum** number of decimal places (rather than a fixed number of decimal places) – i.e. trailing zeroes will be hidden:

```javascript
bytes(1024, {precision: 10});
// output: '1kB'
```

Let me know if there's any changes I can make to help get this merged!