### PR TITLE
Updates bytes to use ISO/IEC 80000-13:2008 units

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 ===
 
   * Remove support for ComponentJS
+  * Adds ISO/IEC 80000-13:2008 format
+    - Adds compatibility mode for parsing older programs
   * Stricter parsing of bytes
     - String is only parsed if units are recognized
 

--- a/Readme.md
+++ b/Readme.md
@@ -174,6 +174,49 @@ bytes('1kB', {mode: compatibility});
 // output: 1024
 ```
 
+
+#### bytes.withDefaultMode(string mode): object
+
+Returns a new module which acts like the `bytes` module, except with the given mode as the default.
+
+
+**Arguments**
+
+| Name          | Type     | Description        |
+|---------------|----------|--------------------|
+| mode          | `string` | Default mode to use   |
+
+**Returns**
+
+| Name    | Type        | Description             |
+|---------|-------------|-------------------------|
+| results | `object` | Returns the byte.js module, with a default mode |
+
+**Example**
+
+```js
+var bytes = require('bytes').withDefaultMode('compatibility');
+
+bytes('1kB');
+// output: 1024
+
+bytes('1KiB');
+// output: 1024
+
+bytes(1024);
+// output: 1 kB
+
+bytes(1024, {mode: 'metric'});
+// output: 1.02kB
+
+bytes('1kB', {mode: 'metric'});
+// output: 1000
+```
+
+
+
+
+
 ## Installation
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,55 @@
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Build Status][travis-image]][travis-url]
 
-Utility to parse a string bytes (ex: `1TB`) to bytes (`1099511627776`) and vice-versa.
+Utility to parse a string bytes (ex: `1TB`) to bytes (`1,000,000,000,000`) and vice-versa.
+
+This uses the byte units defined in ISO/IEC 80000-13:2008, both the binary prefixes and the original SI units.
+
+
+## Supported Units
+
+Supported units and abbreviations are as follows and are case-insensitive:
+
+### Metric/Decimal Prefixes
+
+|      Value       | Abbr |   Name    |
+| ---------------- | ---- | --------- |
+| 1                | B    | byte      |
+| 1000<sup>1</sup> | kB   | kilobyte  |
+| 1000<sup>2</sup> | MB   | megabyte  |
+| 1000<sup>3</sup> | GB   | gigabyte  |
+| 1000<sup>4</sup> | TB   | terabyte  |
+| 1000<sup>5</sup> | PB   | petabyte  |
+| 1000<sup>6</sup> | EB   | exabyte   |
+| 1000<sup>7</sup> | ZB   | zettabyte |
+| 1000<sup>8</sup> | YB   | yottabyte |
+
+
+### Binary Prefixes:
+
+|      Value       | Abbr |   Name    |
+| ---------------- | ---- | --------- |
+| 1                | B    | byte      |
+| 1024<sup>1</sup> | KiB  | kibibyte  |
+| 1024<sup>2</sup> | MiB  | mebibyte  |
+| 1024<sup>3</sup> | GiB  | gibibyte  |
+| 1024<sup>4</sup> | TiB  | tebibyte  |
+| 1024<sup>5</sup> | PiB  | pebibyte  |
+| 1024<sup>6</sup> | EiB  | exbibyte  |
+| 1024<sup>7</sup> | ZiB  | zebibite  |
+| 1024<sup>8</sup> | YiB  | yobibite  |
+
+
+### Compatibility Binary Prefixes
+
+Overwrites the lower units of the metric system with the commonly misused prefixes
+
+|      Value       | Abbr |   Name    |
+| ---------------- | ---- | --------- |
+| 1000<sup>1</sup> | kB   | kilobyte  |
+| 1000<sup>2</sup> | MB   | megabyte  |
+| 1000<sup>3</sup> | GB   | gigabyte  |
+| 1000<sup>4</sup> | TB   | terabyte  |
 
 ## Usage
 
@@ -12,10 +60,18 @@ Utility to parse a string bytes (ex: `1TB`) to bytes (`1099511627776`) and vice-
 var bytes = require('bytes');
 ```
 
-#### bytes.format(number value, [options]): string|null
+
+
+#### bytes.format(value, [options]): string|null
 
 Format the given value in bytes into a string. If the value is negative, it is kept as such. If it is a float, it is
  rounded.
+
+It supports the following output formats:
+
+ * `binary`: uses the binary prefixes (KiB, MiB...)
+ * `decimal`|`metric`: uses the metric system (decimal) prefixes (kB, MB...)
+ * `compatibility`: uses the binary units, but the metric prefixes (kB == 1024B, MB...)
 
 **Arguments**
 
@@ -28,11 +84,12 @@ Format the given value in bytes into a string. If the value is negative, it is k
 
 | Property          | Type   | Description                                                                             |
 |-------------------|--------|-----------------------------------------------------------------------------------------|
-| decimalPlaces | `number`&#124;`null` | Maximum number of decimal places to include in output. Default value to `2`. |
-| fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
-| thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
-| unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value to `''`. |
-
+| decimalPlaces | `number`&#124;`null` | Maximum number of decimal places to include in output. Default value is `2`. |
+| fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value is `false` |
+| thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value is `' '`. |
+| unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value is `''`. |
+| mode         | `string`&124;`null` | Which format to output: `binary`, `metric`, `decimal`, `compatibility`. Default value is `metric` |
+| unit | `string`&#124;`null` | A specific unit to convert to. Default value is `''`. |
 **Returns**
 
 | Name    | Type        | Description             |
@@ -42,42 +99,53 @@ Format the given value in bytes into a string. If the value is negative, it is k
 **Example**
 
 ```js
-bytes(1024);
-// output: '1kB'
-
 bytes(1000);
-// output: '1000B'
+// output: '1kB'
 
 bytes(1000, {thousandsSeparator: ' '});
 // output: '1 000B'
 
+bytes(1024);
+// output: '1.02kB'
+
 bytes(1024 * 1.7, {decimalPlaces: 0});
 // output: '2kB'
 
-bytes(1024, {unitSeparator: ' '});
+bytes(1000, {unitSeparator: ' '});
 // output: '1 kB'
 
+bytes(2048, {mode: 'binary'});
+// output: '2 KiB'
+
+bytes(1024 * 1024 * 2, {unit: 'KiB'});
+// output: '2048 KiB'
+
+bytes(1024 * 1024 * 2, {unit: 'KB'});
+// output: '2097.152 KB'
+
+bytes(1024 * 1024 * 2, {unit: 'KB', mode: 'compatibility'});
+// output: '2048 KB'
 ```
+
+
 
 #### bytes.parse(string value): number|null
 
 Parse the string value into an integer in bytes. If no unit is given, it is assumed the value is in bytes.
 
-Supported units and abbreviations are as follows and are case-insensitive:
+If the unit given has partial bytes, they are dropped (rounded down).
 
-  * "b" for bytes
-  * "kb" for kilobytes
-  * "mb" for megabytes
-  * "gb" for gigabytes
-  * "tb" for terabytes
-
-The units are in powers of two, not ten. This means 1kb = 1024b according to this parser.
 
 **Arguments**
 
-| Name          | Type   | Description        |
-|---------------|--------|--------------------|
-| value   | `string` | String to parse.   |
+| Name          | Type     | Description        |
+|---------------|----------|--------------------|
+| value         | `string` | String to parse.   |
+| options | `Object` | Conversion options |
+
+|       Property       |          Type         | Description |
+| -------------------- | --------------------- | ----------- |
+| mode   | `string`&#124;`null` | Which mode to use (see `bytes.format`) |
 
 **Returns**
 
@@ -89,9 +157,20 @@ The units are in powers of two, not ten. This means 1kb = 1024b according to thi
 
 ```js
 bytes('1kB');
+// output: 1000
+
+bytes('1KiB');
 // output: 1024
 
 bytes('1024');
+// output: 1024
+
+bytes('1.0001 kB');
+// output: 1000
+bytes('1.0001 KiB');
+// output: 1024
+
+bytes('1kB', {mode: compatibility});
 // output: 1024
 ```
 
@@ -101,7 +180,7 @@ bytes('1024');
 npm install bytes --save
 ```
 
-## License 
+## License
 
 [![npm](https://img.shields.io/npm/l/express.svg)](https://github.com/visionmedia/bytes.js/blob/master/LICENSE)
 

--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@
  * Module exports.
  * @public
  */
-
-module.exports = bytes;
-module.exports.format = format;
-module.exports.parse = parse;
+module.exports = withDefaultMode('metric');
 
 /**
  * Module variables.
@@ -133,6 +130,42 @@ function bytes(value, options) {
   }
 
   return null;
+}
+
+/**
+ * Creates a library wrapper that forces a certain mode to be default
+ *
+ * @param {string} mode
+ */
+function withDefaultMode(mode) {
+  // Adds the default mode to the method
+  function setDefault(options) {
+    options = (options !== undefined ? options : {});
+
+    if (options.mode === undefined) {
+      options.mode = mode;
+    }
+
+    return options;
+  }
+
+  function bytesWithDefault(value, options) {
+    return bytes(value, setDefault(options));
+  }
+
+  bytesWithDefault.format = function formatWithDefault(value, options) {
+    return format(value, setDefault(options));
+  };
+
+  bytesWithDefault.parse = function formatWithDefault(value, options) {
+    return parse(value, setDefault(options));
+  };
+
+  // Also allow it to act completely like the original module
+  // So we can still change the default mode (but only by makind a new module)
+  bytesWithDefault.withDefaultMode = withDefaultMode;
+
+  return bytesWithDefault;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
  * Module exports.
  * @public
  */
-module.exports = withDefaultMode('metric');
+module.exports = withDefaultMode('compatibility');
 
 /**
  * Module variables.

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var assert = require('assert');
-var bytes = require('..');
+var bytes = require('..').withDefaultMode('metric');
+
 
 describe('Test byte format function', function(){
   var tb = Math.pow(1000, 4),

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -4,10 +4,16 @@ var assert = require('assert');
 var bytes = require('..');
 
 describe('Test byte format function', function(){
-  var tb = (1 << 30) * 1024,
-      gb = 1 << 30,
-      mb = 1 << 20,
-      kb = 1 << 10;
+  var tb = Math.pow(1000, 4),
+      gb = Math.pow(1000, 3),
+      mb = Math.pow(1000, 2),
+      kb = Math.pow(1000, 1);
+
+  var pib = Math.pow(1024, 5),
+      tib = Math.pow(1024, 4),
+      gib = 1 << 30,
+      mib = 1 << 20,
+      kib = 1 << 10;
 
   it('Should return null if input invalid', function(){
     assert.strictEqual(bytes.format(undefined), null);
@@ -22,31 +28,31 @@ describe('Test byte format function', function(){
     assert.strictEqual(bytes.format({}), null);
   });
 
-  it('Should convert numbers < 1024 to `bytes` string', function(){
+  it('Should convert numbers < 1 000 to `bytes` string', function(){
     assert.equal(bytes.format(0).toLowerCase(), '0b');
     assert.equal(bytes.format(100).toLowerCase(), '100b');
     assert.equal(bytes.format(-100).toLowerCase(), '-100b');
   });
 
-  it('Should convert numbers >= 1 024 to kb string', function(){
+  it('Should convert numbers >= 1 000 to kb string', function(){
     assert.equal(bytes.format(kb).toLowerCase(), '1kb');
     assert.equal(bytes.format(-kb).toLowerCase(), '-1kb');
     assert.equal(bytes.format(2 * kb).toLowerCase(), '2kb');
   });
 
-  it('Should convert numbers >= 1 048 576 to mb string', function(){
+  it('Should convert numbers >= 1 000 000 to mb string', function(){
     assert.equal(bytes.format(mb).toLowerCase(), '1mb');
     assert.equal(bytes.format(-mb).toLowerCase(), '-1mb');
     assert.equal(bytes.format(2 * mb).toLowerCase(), '2mb');
   });
 
-  it('Should convert numbers >= (1 << 30) to gb string', function(){
+  it('Should convert numbers >= 1000^3 to gb string', function(){
     assert.equal(bytes.format(gb).toLowerCase(), '1gb');
     assert.equal(bytes.format(-gb).toLowerCase(), '-1gb');
     assert.equal(bytes.format(2 * gb).toLowerCase(), '2gb');
   });
 
-  it('Should convert numbers >= ((1 << 30) * 1024) to tb string', function(){
+  it('Should convert numbers >= 1000^4 to tb string', function(){
     assert.equal(bytes.format(tb).toLowerCase(), '1tb');
     assert.equal(bytes.format(-tb).toLowerCase(), '-1tb');
     assert.equal(bytes.format(2 * tb).toLowerCase(), '2tb');
@@ -60,29 +66,80 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(tb), '1TB');
   });
 
+  it('Should support compatibility mode', function(){
+    assert.equal(bytes.format(2.2 * kib, {mode: 'compatibility'}).toLowerCase(), '2.2kb');
+    assert.equal(bytes.format(mib, {mode: 'compatibility'}).toLowerCase(), '1mb');
+    assert.equal(bytes.format(gib, {mode: 'compatibility'}).toLowerCase(), '1gb');
+    assert.equal(bytes.format(tib, {mode: 'compatibility'}).toLowerCase(), '1tb');
+    assert.equal(bytes.format(pib, {mode: 'compatibility'}).toLowerCase(), '1024tb');
+  });
+
+  it('Should support metric mode', function(){
+    assert.equal(bytes.format(gb, {mode: 'metric'}).toLowerCase(), '1gb');
+    assert.equal(bytes.format(gb, {mode: 'metric'}).toLowerCase(), '1gb');
+  });
+
+  it('Should support decimal (alias for metric) mode', function(){
+    assert.equal(bytes.format(gb, {mode: 'decimal'}).toLowerCase(), '1gb');
+  });
+
+  it('Should support binary mode', function(){
+    assert.equal(bytes.format(kib, {mode: 'binary'}).toLowerCase(), '1kib');
+    assert.equal(bytes.format(gib, {mode: 'binary'}).toLowerCase(), '1gib');
+  });
+
+  it('Should support using a specific unit', function(){
+    assert.equal(bytes.format(2.2 * kb, {unit: 'B'}).toLowerCase(), '2200b');
+    assert.equal(bytes.format(100 * kb, {unit: 'MB'}).toLowerCase(), '0.1mb');
+    assert.equal(bytes.format(kib, {unit: 'B'}).toLowerCase(), '1024b');
+    assert.equal(bytes.format(1024 * kb, {unit: 'kB'}).toLowerCase(), '1024kb');
+  });
+
+  it('Should allow units to be case insensitive', function(){
+    assert.equal(bytes.format(kib, {unit: 'b'}).toLowerCase(), '1024b');
+    assert.equal(bytes.format(kib, {unit: 'B'}).toLowerCase(), '1024b');
+    assert.equal(bytes.format(kb, {unit: 'kB'}).toLowerCase(), '1kb');
+  });
+
+  it('Should support using a specific unit in compatibility mode', function(){
+    assert.equal(bytes.format(1, {unit: 'b', mode:'compatibility'}).toLowerCase(), '1b');
+    assert.equal(bytes.format(kib, {unit: 'kb', mode:'compatibility'}).toLowerCase(), '1kb');
+    assert.equal(bytes.format(mib, {unit: 'mb', mode:'compatibility'}).toLowerCase(), '1mb');
+    assert.equal(bytes.format(gib, {unit: 'gb', mode:'compatibility'}).toLowerCase(), '1gb');
+    assert.equal(bytes.format(tib, {unit: 'tb', mode:'compatibility'}).toLowerCase(), '1tb');
+  });
+
+  it('Should support other units in compatibility mode', function(){
+    assert.equal(bytes.format(kib, {unit: 'kib', mode:'compatibility'}).toLowerCase(), '1kib');
+    assert.equal(bytes.format(tib, {unit: 'tib', mode:'compatibility'}).toLowerCase(), '1tib');
+  });
+
   it('Support custom thousands separator', function(){
-    assert.equal(bytes.format(1000).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ''}).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: null}).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: '.'}).toLowerCase(), '1.000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ','}).toLowerCase(), '1,000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ' '}).toLowerCase(), '1 000b');
+    assert.equal(bytes.format(1000, {mode: 'binary'}).toLowerCase(), '1000b');
+    assert.equal(bytes.format(1000, {mode: 'binary', thousandsSeparator: ''}).toLowerCase(), '1000b');
+    assert.equal(bytes.format(1000, {mode: 'binary', thousandsSeparator: null}).toLowerCase(), '1000b');
+    assert.equal(bytes.format(1000, {mode: 'binary', thousandsSeparator: '.'}).toLowerCase(), '1.000b');
+    assert.equal(bytes.format(1000, {mode: 'binary', thousandsSeparator: ','}).toLowerCase(), '1,000b');
+    assert.equal(bytes.format(1000, {mode: 'binary', thousandsSeparator: ' '}).toLowerCase(), '1 000b');
   });
 
   it('Should custom unit separator', function(){
-    assert.equal(bytes.format(1024), '1kB');
-    assert.equal(bytes.format(1024, {unitSeparator: ''}), '1kB');
-    assert.equal(bytes.format(1024, {unitSeparator: null}), '1kB');
-    assert.equal(bytes.format(1024, {unitSeparator: ' '}), '1 kB');
-    assert.equal(bytes.format(1024, {unitSeparator: '\t'}), '1\tkB');
+    assert.equal(bytes.format(kb), '1kB');
+    assert.equal(bytes.format(kb, {unitSeparator: ''}), '1kB');
+    assert.equal(bytes.format(kb, {unitSeparator: null}), '1kB');
+    assert.equal(bytes.format(kb, {unitSeparator: ' '}), '1 kB');
+    assert.equal(bytes.format(kb, {unitSeparator: '\t'}), '1\tkB');
   });
 
   it('Should support custom number of decimal places', function(){
-    assert.equal(bytes.format(kb - 1, {decimalPlaces: 0}).toLowerCase(), '1023b');
+    assert.equal(bytes.format(kb - 1, {decimalPlaces: 0}).toLowerCase(), '999b');
+    assert.equal(bytes.format(kib, {decimalPlaces: 0}).toLowerCase(), '1kb');
     assert.equal(bytes.format(kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
     assert.equal(bytes.format(1.4 * kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
     assert.equal(bytes.format(1.5 * kb, {decimalPlaces: 0}).toLowerCase(), '2kb');
-    assert.equal(bytes.format(kb - 1, {decimalPlaces: 1}).toLowerCase(), '1023b');
+
+    assert.equal(bytes.format(kb - 1, {decimalPlaces: 1}).toLowerCase(), '999b');
+    assert.equal(bytes.format(kib, {decimalPlaces: 1}).toLowerCase(), '1kb');
     assert.equal(bytes.format(kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
     assert.equal(bytes.format(1.04 * kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
     assert.equal(bytes.format(1.05 * kb, {decimalPlaces: 1}).toLowerCase(), '1.1kb');
@@ -96,5 +153,6 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(1.2 * mb).toLowerCase(), '1.2mb');
     assert.equal(bytes.format(-1.2 * mb).toLowerCase(), '-1.2mb');
     assert.equal(bytes.format(1.2 * kb).toLowerCase(), '1.2kb');
-  })
+  });
 });
+

--- a/test/byte-parse.js
+++ b/test/byte-parse.js
@@ -24,52 +24,53 @@ describe('Test byte parse function', function(){
     assert.strictEqual(bytes.parse(10.5), 10.5);
   });
 
+  it('Should parse bytes', function(){
+    assert.equal(bytes.parse('1B'), 1);
+    assert.equal(bytes.parse('123B'), 123);
+  });
+
+  it('Should parse KiB', function(){
+    assert.equal(bytes.parse('1KiB'), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('0.5KiB'), 0.5 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1.5KiB'), 1.5 * Math.pow(1024, 1));
+  });
+
+  it('Should parse upper binary units', function(){
+    assert.equal(bytes.parse('1MiB'), 1 * Math.pow(1024, 2));
+    assert.equal(bytes.parse('1GiB'), 1 * Math.pow(1024, 3));
+    assert.equal(bytes.parse('1TiB'), 1 * Math.pow(1024, 4));
+    assert.equal(bytes.parse('1PiB'), 1 * Math.pow(1024, 5));
+    assert.equal(bytes.parse('1EiB'), 1 * Math.pow(1024, 6));
+    assert.equal(bytes.parse('1ZiB'), 1 * Math.pow(1024, 7));
+    assert.equal(bytes.parse('1YiB'), 1 * Math.pow(1024, 8));
+  });
+
   it('Should parse kB', function(){
-    assert.equal(bytes.parse('1kb'), 1 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1KB'), 1 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1Kb'), 1 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1kB'), 1 * Math.pow(1024, 1));
-
-    assert.equal(bytes.parse('0.5kb'), 0.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('0.5KB'), 0.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('0.5Kb'), 0.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('0.5kB'), 0.5 * Math.pow(1024, 1));
-
-    assert.equal(bytes.parse('1.5kb'), 1.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1.5KB'), 1.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1.5Kb'), 1.5 * Math.pow(1024, 1));
-    assert.equal(bytes.parse('1.5kB'), 1.5 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1kB'), 1 * Math.pow(1000, 1));
+    assert.equal(bytes.parse('0.5kB'), 0.5 * Math.pow(1000, 1));
+    assert.equal(bytes.parse('1.5kB'), 1.5 * Math.pow(1000, 1));
   });
 
-  it('Should parse MB', function(){
-    assert.equal(bytes.parse('1mb'), 1 * Math.pow(1024, 2));
-    assert.equal(bytes.parse('1MB'), 1 * Math.pow(1024, 2));
-    assert.equal(bytes.parse('1Mb'), 1 * Math.pow(1024, 2));
-    assert.equal(bytes.parse('1mB'), 1 * Math.pow(1024, 2));
+  it('Should parse upper metric units', function(){
+    assert.equal(bytes.parse('1MB'), 1 * Math.pow(1000, 2));
+    assert.equal(bytes.parse('1GB'), 1 * Math.pow(1000, 3));
+    assert.equal(bytes.parse('1TB'), 1 * Math.pow(1000, 4));
+    assert.equal(bytes.parse('1PB'), 1 * Math.pow(1000, 5));
+    assert.equal(bytes.parse('1EB'), 1 * Math.pow(1000, 6));
+    assert.equal(bytes.parse('1ZB'), 1 * Math.pow(1000, 7));
+    assert.equal(bytes.parse('1YB'), 1 * Math.pow(1000, 8));
   });
 
-  it('Should parse GB', function(){
-    assert.equal(bytes.parse('1gb'), 1 * Math.pow(1024, 3));
-    assert.equal(bytes.parse('1GB'), 1 * Math.pow(1024, 3));
-    assert.equal(bytes.parse('1Gb'), 1 * Math.pow(1024, 3));
-    assert.equal(bytes.parse('1gB'), 1 * Math.pow(1024, 3));
+  it('Should parse compatibility units', function(){
+    assert.equal(bytes.parse('1KB', {mode: 'compatibility'}), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1MB', {mode: 'compatibility'}), 1 * Math.pow(1024, 2));
+    assert.equal(bytes.parse('1GB', {mode: 'compatibility'}), 1 * Math.pow(1024, 3));
+    assert.equal(bytes.parse('1TB', {mode: 'compatibility'}), 1 * Math.pow(1024, 4));
   });
 
-  it('Should parse TB', function(){
-    assert.equal(bytes.parse('1tb'), 1 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1TB'), 1 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1Tb'), 1 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1tB'), 1 * Math.pow(1024, 4));
-
-    assert.equal(bytes.parse('0.5tb'), 0.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('0.5TB'), 0.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('0.5Tb'), 0.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('0.5tB'), 0.5 * Math.pow(1024, 4));
-
-    assert.equal(bytes.parse('1.5tb'), 1.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1.5TB'), 1.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1.5Tb'), 1.5 * Math.pow(1024, 4));
-    assert.equal(bytes.parse('1.5tB'), 1.5 * Math.pow(1024, 4));
+  it('Should parse remaining normal units in compatibility mode', function(){
+    assert.equal(bytes.parse('1B', {mode: 'compatibility'}), 1);
+    assert.equal(bytes.parse('1YB', {mode: 'compatibility'}), 1 * Math.pow(1000, 8));
   });
 
   it('Should assume bytes when no units', function(){
@@ -81,15 +82,23 @@ describe('Test byte parse function', function(){
   it('Should accept negative values', function(){
     assert.equal(bytes.parse('-1'), -1);
     assert.equal(bytes.parse('-1024'), -1024);
-    assert.equal(bytes.parse('-1.5TB'), -1.5 * Math.pow(1024, 4));
+    assert.equal(bytes.parse('-1.5TB'), -1.5 * Math.pow(1000, 4));
   });
 
   it('Should drop partial bytes', function(){
     assert.equal(bytes.parse('1.1b'), 1);
-    assert.equal(bytes.parse('1.0001kb'), 1024);
+    assert.equal(bytes.parse('1.0001kb'), 1000);
   });
 
   it('Should allow whitespace', function(){
-    assert.equal(bytes.parse('1 TB'), 1 * Math.pow(1024, 4));
+    assert.equal(bytes.parse('1 TiB'), 1 * Math.pow(1024, 4));
+  });
+
+  it('Should parse case-insensitively', function(){
+    assert.equal(bytes.parse('1kib'), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1KiB'), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1Kib'), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1kiB'), 1 * Math.pow(1024, 1));
+    assert.equal(bytes.parse('1KIB'), 1 * Math.pow(1024, 1));
   });
 });

--- a/test/byte-parse.js
+++ b/test/byte-parse.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('assert');
-var bytes = require('..');
+var bytes = require('..').withDefaultMode('metric');
 
 describe('Test byte parse function', function(){
   it('Should return null if input invalid', function(){

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -10,16 +10,16 @@ describe('Test constructor', function(){
 
   it('Shoud be able to parse a string into a number', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes('1kB'), 1024);
+    assert.equal(bytes('1kB'), 1000);
   });
 
   it('Should convert a number into a string', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes(1024), '1kB');
+    assert.equal(bytes(1000), '1kB');
   });
 
   it('Should convert a number into a string with options', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes(1000, {thousandsSeparator: ' '}), '1 000B');
+    assert.equal(bytes(1000, {unitSeparator: '---'}), '1---kB');
   });
 });

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -10,17 +10,17 @@ describe('Test constructor', function(){
 
   it('Shoud be able to parse a string into a number', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes('1kB'), 1000);
+    assert.equal(bytes('1kB'), 1024);
   });
 
   it('Should convert a number into a string', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes(1000), '1kB');
+    assert.equal(bytes(1024), '1kB');
   });
 
   it('Should convert a number into a string with options', function(){
     // This function is testes more accurately in another test suite
-    assert.equal(bytes(1000, {unitSeparator: '---'}), '1---kB');
+    assert.equal(bytes(1024, {unitSeparator: '---'}), '1---kB');
   });
 });
 
@@ -54,7 +54,7 @@ describe('Test withDefaultMode', function(){
   });
 
   it('Should not affect older modules', function(){
-    assert.equal(bytes.format(1024), '1.02kB');
+    assert.equal(bytes.format(1024), '1kB');
     assert.equal(binary.format(1024), '1KiB');
   });
 });

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -23,3 +23,39 @@ describe('Test constructor', function(){
     assert.equal(bytes(1000, {unitSeparator: '---'}), '1---kB');
   });
 });
+
+describe('Test withDefaultMode', function(){
+  var compatibility = bytes.withDefaultMode('compatibility');
+  var binary = bytes.withDefaultMode('binary');
+
+  it('Expect a function', function(){
+    assert.equal(typeof compatibility, 'function');
+  });
+
+  it('Shoud still be able to parse a string into a number', function(){
+    assert.equal(compatibility('1kB'), 1024);
+  });
+
+  it('Shoud still accept other modes', function(){
+    assert.equal(compatibility('1kB', {mode: 'metric'}), 1000);
+  });
+
+
+  it('Should still convert a number into a string', function(){
+    assert.equal(compatibility(1024), '1kB');
+  });
+
+  it('Should run parse properly', function(){
+    assert.equal(compatibility.parse('1kB'), 1024);
+  });
+
+  it('Should run format properly', function(){
+    assert.equal(compatibility.format(1024), '1kB');
+  });
+
+  it('Should not affect older modules', function(){
+    assert.equal(bytes.format(1024), '1.02kB');
+    assert.equal(binary.format(1024), '1KiB');
+  });
+});
+


### PR DESCRIPTION
I've updated bytes.js to allow a more diverse set of units, as well as making it conform to the ISO/IEC 80000-13:2008 format.

Since this changes the default units, it would need a version bump to a 3.0.0 version (so I updated that too)

This is split into 2 commits. 57ae5ea3b50bc5561bf318f750437427b582e4ec adds a way to specify a default set of units to convert to, which results in minimal code updates for people upgrading versions.

Elements Added:
- Changes default units to follow the ISO/IEC 80000-13:2008 format
- Adds a compatibility mode to allow previous uses, (as well as allow parsing older program outputs)
- Updates readme to reflect changes (and some general cleanup)
- Adds relevant tests

Closes:
- #19: adds a `unit` field, though no shorthand for it
- #26: allow binary prefixes
