### PR TITLE
add outputUnit option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
 | unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value to `''`. |
-| outputUnit | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
+| unit | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
 
 **Returns**
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,8 +31,8 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | decimalPlaces | `number`&#124;`null` | Maximum number of decimal places to include in output. Default value to `2`. |
 | fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
+| unit | `string`&#124;`null` | The unit in which the result will be returned (B/KB/MB/GB/TB). Default value to `''` (which means auto detect). |
 | unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value to `''`. |
-| unit | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
 
 **Returns**
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
 | unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value to `''`. |
-| unitToUse | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
+| outputUnit | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
 
 **Returns**
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@ Format the given value in bytes into a string. If the value is negative, it is k
 | fixedDecimals | `boolean`&#124;`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
 | thousandsSeparator | `string`&#124;`null` | Example of values: `' '`, `','` and `.`... Default value to `' '`. |
 | unitSeparator | `string`&#124;`null` | Separator to use between number and unit. Default value to `''`. |
+| unitToUse | `string`&#124;`null` | The unit in which the result will be returned (TB/GB/MB/KB/B). Default value to `''` (which means auto detect). |
 
 **Returns**
 

--- a/index.js
+++ b/index.js
@@ -93,10 +93,10 @@ function format(value, options) {
   var unitSeparator = (options && options.unitSeparator) || '';
   var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
   var fixedDecimals = Boolean(options && options.fixedDecimals);
-  var unit = (options && options.unit) || '';
-  var unit = unit || 'B';
+  var outputUnit = (options && options.unit) || '';
+  var unit = outputUnit || 'B';
 
-  if (!unit) {
+  if (!outputUnit) {
     if (mag >= map.tb) {
       unit = 'TB';
     } else if (mag >= map.gb) {

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function bytes(value, options) {
  * @param {number} [options.fixedDecimals=false]
  * @param {string} [options.thousandsSeparator=]
  * @param {string} [options.unitSeparator=]
- * @param {string} [options.unitToUse=]
+ * @param {string} [options.outputUnit=]
  *
  * @returns {string|null}
  * @public
@@ -93,10 +93,10 @@ function format(value, options) {
   var unitSeparator = (options && options.unitSeparator) || '';
   var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
   var fixedDecimals = Boolean(options && options.fixedDecimals);
-  var unitToUse = (options && options.unitToUse) || '';
-  var unit = unitToUse || 'B';
+  var outputUnit = (options && options.outputUnit) || '';
+  var unit = outputUnit || 'B';
 
-  if (!unitToUse) {
+  if (!outputUnit) {
     if (mag >= map.tb) {
       unit = 'TB';
     } else if (mag >= map.gb) {

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function bytes(value, options) {
  * @param {number} [options.fixedDecimals=false]
  * @param {string} [options.thousandsSeparator=]
  * @param {string} [options.unitSeparator=]
- * @param {string} [options.outputUnit=]
+ * @param {string} [options.unit=]
  *
  * @returns {string|null}
  * @public
@@ -93,10 +93,10 @@ function format(value, options) {
   var unitSeparator = (options && options.unitSeparator) || '';
   var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
   var fixedDecimals = Boolean(options && options.fixedDecimals);
-  var outputUnit = (options && options.outputUnit) || '';
-  var unit = outputUnit || 'B';
+  var unit = (options && options.unit) || '';
+  var unit = unit || 'B';
 
-  if (!outputUnit) {
+  if (!unit) {
     if (mag >= map.tb) {
       unit = 'TB';
     } else if (mag >= map.gb) {

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ function bytes(value, options) {
  * @param {number} [options.fixedDecimals=false]
  * @param {string} [options.thousandsSeparator=]
  * @param {string} [options.unitSeparator=]
+ * @param {string} [options.unitToUse=]
  *
  * @returns {string|null}
  * @public
@@ -92,16 +93,19 @@ function format(value, options) {
   var unitSeparator = (options && options.unitSeparator) || '';
   var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
   var fixedDecimals = Boolean(options && options.fixedDecimals);
-  var unit = 'B';
+  var unitToUse = (options && options.unitToUse) || '';
+  var unit = unitToUse || 'B';
 
-  if (mag >= map.tb) {
-    unit = 'TB';
-  } else if (mag >= map.gb) {
-    unit = 'GB';
-  } else if (mag >= map.mb) {
-    unit = 'MB';
-  } else if (mag >= map.kb) {
-    unit = 'kB';
+  if (!unitToUse) {
+    if (mag >= map.tb) {
+      unit = 'TB';
+    } else if (mag >= map.gb) {
+      unit = 'GB';
+    } else if (mag >= map.mb) {
+      unit = 'MB';
+    } else if (mag >= map.kb) {
+      unit = 'kB';
+    }
   }
 
   var val = value / map[unit.toLowerCase()];

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ function bytes(value, options) {
  * @param {number} [options.decimalPlaces=2]
  * @param {number} [options.fixedDecimals=false]
  * @param {string} [options.thousandsSeparator=]
- * @param {string} [options.unitSeparator=]
  * @param {string} [options.unit=]
+ * @param {string} [options.unitSeparator=]
  *
  * @returns {string|null}
  * @public

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -99,16 +99,16 @@ describe('Test byte format function', function(){
   })
 
   it('Should support user supplied unit choice', function(){
-    assert.equal(bytes.format(12, {outputUnit: 'b'}).toLowerCase(), '12b');
-    assert.equal(bytes.format(12 * kb, {outputUnit: 'kb'}).toLowerCase(), '12kb');
-    assert.equal(bytes.format(12 * mb, {outputUnit: 'mb'}).toLowerCase(), '12mb');
-    assert.equal(bytes.format(12 * gb, {outputUnit: 'gb'}).toLowerCase(), '12gb');
-    assert.equal(bytes.format(12 * tb, {outputUnit: 'tb'}).toLowerCase(), '12tb');
+    assert.equal(bytes.format(12, {unit: 'b'}).toLowerCase(), '12b');
+    assert.equal(bytes.format(12 * kb, {unit: 'kb'}).toLowerCase(), '12kb');
+    assert.equal(bytes.format(12 * mb, {unit: 'mb'}).toLowerCase(), '12mb');
+    assert.equal(bytes.format(12 * gb, {unit: 'gb'}).toLowerCase(), '12gb');
+    assert.equal(bytes.format(12 * tb, {unit: 'tb'}).toLowerCase(), '12tb');
 
     // check for conversions
-    assert.equal(bytes.format(12 * mb, {outputUnit: 'b'}).toLowerCase(), '12582912b');
-    assert.equal(bytes.format(12 * mb, {outputUnit: 'kb'}).toLowerCase(), '12288kb');
-    assert.equal(bytes.format(12 * gb, {outputUnit: 'mb'}).toLowerCase(), '12288mb');
-    assert.equal(bytes.format(12 * tb, {outputUnit: 'gb'}).toLowerCase(), '12288gb');
+    assert.equal(bytes.format(12 * mb, {unit: 'b'}).toLowerCase(), '12582912b');
+    assert.equal(bytes.format(12 * mb, {unit: 'kb'}).toLowerCase(), '12288kb');
+    assert.equal(bytes.format(12 * gb, {unit: 'mb'}).toLowerCase(), '12288mb');
+    assert.equal(bytes.format(12 * tb, {unit: 'gb'}).toLowerCase(), '12288gb');
   })
 });

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -97,4 +97,12 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(-1.2 * mb).toLowerCase(), '-1.2mb');
     assert.equal(bytes.format(1.2 * kb).toLowerCase(), '1.2kb');
   })
+
+  it('Should support user supplied unit choice', function(){
+    assert.equal(bytes.format(12, {unitToUse: 'b'}).toLowerCase(), '12b');
+    assert.equal(bytes.format(12 * kb, {unitToUse: 'kb'}).toLowerCase(), '12kb');
+    assert.equal(bytes.format(12 * mb, {unitToUse: 'mb'}).toLowerCase(), '12mb');
+    assert.equal(bytes.format(12 * gb, {unitToUse: 'gb'}).toLowerCase(), '12gb');
+    assert.equal(bytes.format(12 * tb, {unitToUse: 'tb'}).toLowerCase(), '12tb');
+  })
 });

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -99,10 +99,10 @@ describe('Test byte format function', function(){
   })
 
   it('Should support user supplied unit choice', function(){
-    assert.equal(bytes.format(12, {unitToUse: 'b'}).toLowerCase(), '12b');
-    assert.equal(bytes.format(12 * kb, {unitToUse: 'kb'}).toLowerCase(), '12kb');
-    assert.equal(bytes.format(12 * mb, {unitToUse: 'mb'}).toLowerCase(), '12mb');
-    assert.equal(bytes.format(12 * gb, {unitToUse: 'gb'}).toLowerCase(), '12gb');
-    assert.equal(bytes.format(12 * tb, {unitToUse: 'tb'}).toLowerCase(), '12tb');
+    assert.equal(bytes.format(12, {outputUnit: 'b'}).toLowerCase(), '12b');
+    assert.equal(bytes.format(12 * kb, {outputUnit: 'kb'}).toLowerCase(), '12kb');
+    assert.equal(bytes.format(12 * mb, {outputUnit: 'mb'}).toLowerCase(), '12mb');
+    assert.equal(bytes.format(12 * gb, {outputUnit: 'gb'}).toLowerCase(), '12gb');
+    assert.equal(bytes.format(12 * tb, {outputUnit: 'tb'}).toLowerCase(), '12tb');
   })
 });

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -104,5 +104,11 @@ describe('Test byte format function', function(){
     assert.equal(bytes.format(12 * mb, {outputUnit: 'mb'}).toLowerCase(), '12mb');
     assert.equal(bytes.format(12 * gb, {outputUnit: 'gb'}).toLowerCase(), '12gb');
     assert.equal(bytes.format(12 * tb, {outputUnit: 'tb'}).toLowerCase(), '12tb');
+
+    // check for conversions
+    assert.equal(bytes.format(12 * mb, {outputUnit: 'b'}).toLowerCase(), '12582912b');
+    assert.equal(bytes.format(12 * mb, {outputUnit: 'kb'}).toLowerCase(), '12288kb');
+    assert.equal(bytes.format(12 * gb, {outputUnit: 'mb'}).toLowerCase(), '12288mb');
+    assert.equal(bytes.format(12 * tb, {outputUnit: 'gb'}).toLowerCase(), '12288gb');
   })
 });


### PR DESCRIPTION
This PR will let the user to define an outputUnit option to choose the unit in which he wishes to receive the output from `bytes.js`