### PR TITLE
Fix parsing of byte strings lacking leading 0 before decimal

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var map = {
   pb: Math.pow(1024, 5),
 };
 
-var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+var parseRegExp = /^((-|\+)?(\d*(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
 
 /**
  * Convert the given value in bytes into a string or parse to string to an integer in bytes.

--- a/test/byte-parse.js
+++ b/test/byte-parse.js
@@ -13,6 +13,7 @@ describe('Test byte parse function', function(){
     assert.strictEqual(bytes.parse(function(){}), null);
     assert.strictEqual(bytes.parse({}), null);
     assert.strictEqual(bytes.parse('foobar'), null);
+    assert.strictEqual(bytes.parse('.5'), null);
   });
 
   it('Should parse raw number', function(){
@@ -97,6 +98,7 @@ describe('Test byte parse function', function(){
   it('Should accept negative values', function(){
     assert.equal(bytes.parse('-1'), -1);
     assert.equal(bytes.parse('-1024'), -1024);
+    assert.equal(bytes.parse('-.5TB'), -0.5 * Math.pow(1024, 4));
     assert.equal(bytes.parse('-1.5TB'), -1.5 * Math.pow(1024, 4));
   });
 
@@ -107,5 +109,10 @@ describe('Test byte parse function', function(){
 
   it('Should allow whitespace', function(){
     assert.equal(bytes.parse('1 TB'), 1 * Math.pow(1024, 4));
+  });
+
+  it('Should parse decimal strings without a leading 0', function(){
+    assert.equal(bytes.parse('.5GB'), bytes.parse('0.5GB'));
+    assert.equal(bytes.parse('.25tb'), bytes.parse('0.25TB'));
   });
 });


### PR DESCRIPTION
I noticed the following issue:

```ts
> bytes.parse('.25GB');
null
> bytes.parse('0.25GB');
268435456
```

where if a leading 0 is not supplied, `null` is always returned. I updated the parse regex to look for 0 or more leading digits so that `'.25GB'` could be parsed correctly, and added some tests to verify that omitting a leading 0 returns the same result as supplying one.